### PR TITLE
on mount focussing based on custom prop

### DIFF
--- a/src/createReactiveClass.js
+++ b/src/createReactiveClass.js
@@ -8,10 +8,15 @@ export default function createReactiveClass(tag) {
       this.displayName = `ReactiveElement-${tag}`;
       this.state = pickProps(props, (key, value) => !isRxObservable(value));
       this.state.mount = true;
+      this.inputRef = tag === 'input' && props['autofocusonmount'] ? React.createRef() : null;
     }
 
     UNSAFE_componentWillMount() {
       this.subscribe(this.props);
+    }
+
+    componentDidMount() {
+      if(this.inputRef) this.inputRef.focus();
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) {
@@ -63,6 +68,9 @@ export default function createReactiveClass(tag) {
       }
 
       const finalProps = pickProps(this.state, (key) => key !== 'mount');
+
+      if(this.inputRef) finalProps.ref = this.inputRef;
+
       return React.createElement(tag, finalProps);
     }
   }


### PR DESCRIPTION
Only generates a ref for component if the tag is an input and a custom prop is passed

Usage: 
```
<TextInput
          autofocusonmount="true"
          name="email"
          answer$={email$}
          eventStreams={{
            newValue$: eventStreams.updateEmail$,
            arrowUp$: new Subject(),
            arrowDown$: new Subject(),
            blur$: new Subject(),
            enter$: nextClicked$
          }}
        />
```